### PR TITLE
adding hackathon in august

### DIFF
--- a/src/logic/opportunities.ts
+++ b/src/logic/opportunities.ts
@@ -741,6 +741,13 @@ export const opportunities = [
     deadline: '31 August 2021',
     type: 'Scholarship',
   },
+
+  {
+    name: 'Hack-O-Uplift',
+    link: 'https://uplift.girlscript.tech/hack-o-uplift',
+    deadline: '30 August 2021',
+    type: 'Hackathon',
+  },
   //end of aug
   
   //start of sept


### PR DESCRIPTION
# Related Issue
*issue goes here with issue number*

# Summary
*Provide an overview*

# Update type?
- [ ] Adding Opportunity
- [ ] UI Update
# If adding new opportunity
- Deadline should be <date> <day>
    - ✔ 15 August : If the available deadline is previous years then do not add date 
    - ✔ 15 August 2021 : If available deadline is of present year
    - ✔ August: If you are not sure of the exact date, but the deadline lies in August.
    - ❌ August 15
    - ❌ Aug 15
    - ❌ 2021 Aug 15
    - ❌ 15 Aug 21
- If an opportunity is for women add the Women word in type section
Make sure the added opportunity is in the specified format:
```js
{
    name: 'Name of the event',
    link: 'https://valid-url-to-explanation',
    deadline: 'deadline or range',
    type: 'whether a mentorship, internship or hackathon',
}
```

# Proposed Changes
- change 1
- change 2
- ...

# Screenshots

|           Original        |         Updated          |
|---------------------------|--------------------------|
| ** Original screenshot ** | ** updated screenshot ** |
