### PR TITLE
Update opportunities.ts

### DIFF
--- a/src/logic/opportunities.ts
+++ b/src/logic/opportunities.ts
@@ -222,7 +222,7 @@ export const opportunities = [
    {
     name: 'Global Impact Scholarship',
     link: 'https://www.palantir.com/careers/students/scholarship/global-impact/',
-    deadline: '15 March 2022',
+    deadline: '17 March 2022',
     type: 'Scholarship',
   },
   {


### PR DESCRIPTION
# Related Issue
Date of deadline is updated, added new date 

Palantir Global Impact Scholarship - The 2022 application period is now open. The deadline to apply is Thursday 17 March 2022 at 4:00 PM PST.

