### PR TITLE
Add Adobe Design Circle+Spark AR CAP+Summer of Nix

### DIFF
--- a/src/logic/opportunities.ts
+++ b/src/logic/opportunities.ts
@@ -252,6 +252,12 @@ export const opportunities = [
     type: 'Scholarship',
   },
   {
+    name: 'Adobe Design Circle Scholarship',
+    link: 'https://www.iie.org/en/Programs/Adobe-Design-Circle-Scholarships',
+    deadline: '14 March',
+    type: 'Scholarship',
+  },
+  {
     name: 'Summer Of Bitcoin',
     link: 'https://www.summerofbitcoin.org/',
     deadline: '15 March 2022',
@@ -517,6 +523,12 @@ export const opportunities = [
     link: 'https://www.sydney.edu.au/science/industry-and-community/community-engagement/international-science-school.html',
     deadline: '14 May',
     type: 'Conference',
+  },
+  {
+    name: 'Summer of Nix',
+    link: 'https://summer.nixos.org/',
+    deadline: '15 May',
+    type: 'Open Source Internship',
   },
   {
     name: 'Girl Up Scholarship',
@@ -907,7 +919,12 @@ export const opportunities = [
     deadline: '30 September',
     type: 'Scholarship for Women',
   },
-
+  {
+    name: 'Spark AR Campus Ambassador Program',
+    link: 'https://sparkar.reskilll.com/campus',
+    deadline: 'Late September',
+    type: 'Campus Ambassador',
+  },
   //end of sept
   
   //start of oct


### PR DESCRIPTION


# Related Issue
Nil

# Summary
Added links and deadlines for the Adobe Design Circle Scholarship, Spark AR Campus Ambassador Program and Summer of Nix Program.

# Update type?
- [x] Adding Opportunity
- [ ] UI Update
# If adding new opportunity
- Deadline should be <date> <day>
    - ✔ 15 August : If the available deadline is previous years then do not add date 
    - ✔ 15 August 2021 : If available deadline is of present year
    - ✔ August: If you are not sure of the exact date, but the deadline lies in August.
    - ❌ August 15
    - ❌ Aug 15
    - ❌ 2021 Aug 15
    - ❌ 15 Aug 21
- If an opportunity is for women add the Women word in type section
Make sure the added opportunity is in the specified format:
```js
{
    name: 'Name of the event',
    link: 'https://valid-url-to-explanation',
    deadline: 'deadline or range',
    type: 'whether a mentorship, internship or hackathon',
}
```

# Proposed Changes
- change 1
- change 2
- ...

# Screenshots

|           Original        |         Updated          |
|---------------------------|--------------------------|
| ** Original screenshot ** | ** updated screenshot ** |
