### PR TITLE
Add conferences and ideathons

### DIFF
--- a/src/logic/opportunities.ts
+++ b/src/logic/opportunities.ts
@@ -592,6 +592,14 @@ export const opportunities = [
     deadline: '11 June',
     type: 'Full Time SDE roles',
   },
+  
+  {
+    name: 'Tata Steel - Women of Mettle',
+    link: 'https://xathon.mettl.com/event/women-of-mettle',
+    deadline: '12 June',
+    type: 'Scholarship + PPI/PPO Offer',
+  },
+  
   {
     name: 'Polygon Fellowship: Web3 Builder Track',
     link: 'https://polygon.technology/polygon-fellowship/',
@@ -617,6 +625,12 @@ export const opportunities = [
     deadline: '30 Jun',
     type: 'Mentorship',
   },
+  {
+    name: 'MLH Hackcon X',
+    link: 'https://hackcon.mlh.io/',
+    deadline: 'June',
+    type: 'Conference',
+  },
   
   //End of June
   
@@ -633,6 +647,12 @@ export const opportunities = [
     link: 'https://events.withgoogle.com/get-ahead-apac-2019/#content',
     deadline: 'July',
     type: 'Fellowship',
+  },
+  {
+    name: 'Cisco Ideathon',
+    link: 'hhttps://www.cisco.com/c/m/en_in/customer-experience-academy.html',
+    deadline: '6 July, 2022',
+    type: 'Ideathon + Internship at Cisco',
   },
   {
     name: 'Flipkart GRiD 3.0',
@@ -705,6 +725,12 @@ export const opportunities = [
     link: 'https://inthecloud.withgoogle.com/google-cloud-skills/register.html?utm_source=google&utm_medium=blog&utm_campaign=FY21-Q1-global-trainingandenablement-website-other-skills_challenge&utm_content=q1rollup',
     deadline: '30 July',
     type: 'Skills challenge',
+  },
+  {
+    name: 'Samsung Solve for Tomorrow',
+    link: 'https://www.samsung.com/in/solvefortomorrow/?cid=in_paid_ppc_google_allproducts_none_allproducts-eshop-bau-dsa_text_20200105_719335193-40302839271---446538506521-aud-747500539912:dsa-904431574476-1ur-501336l-2022&gclid=Cj0KCQjwtvqVBhCVARIsAFUxcRtHBp4CWOng21pcT5djxsCgGk8aS-_FsqHNtjyrlq0TqCzzkCx41g8aAoBOEALw_wcB',
+    deadline: '31 July',
+    type: 'Ideathon + Incubation support and mentorship',
   },
   //End of july
   
@@ -862,6 +888,7 @@ export const opportunities = [
     deadline: '30 August 2021',
     type: 'Hackathon',
   },
+
   //end of aug
   
   //start of sept
@@ -912,6 +939,13 @@ export const opportunities = [
     link: 'https://www.drdo.gov.in/sites/default/files/whats_new_document/advt_ardb2020.pdf',
     deadline: '30 September',
     type: 'Scholarship for Women',
+  },
+
+  {
+    name: 'GitHub Universe',
+    link: 'https://www.githubuniverse.com/',
+    deadline: 'September',
+    type: 'Conference',
   },
 
   //end of sept


### PR DESCRIPTION
# Related Issue
*issue goes here with issue number*

# Summary
*Provide an overview*

# Update type?
- [X] Adding Opportunity
- [ ] UI Update
# If adding new opportunity
- Deadline should be <date> <day>
    - ✔ 15 August : If the available deadline is previous years then do not add date 
    - ✔ 15 August 2021 : If available deadline is of present year
    - ✔ August: If you are not sure of the exact date, but the deadline lies in August.
    - ❌ August 15
    - ❌ Aug 15
    - ❌ 2021 Aug 15
    - ❌ 15 Aug 21
- If an opportunity is for women add the Women word in type section
Make sure the added opportunity is in the specified format:
```js
{
    name: 'Name of the event',
    link: 'https://valid-url-to-explanation',
    deadline: 'deadline or range',
    type: 'whether a mentorship, internship or hackathon',
}
```

# Proposed Changes
- change 1
- change 2
- ...

# Screenshots

|           Original        |         Updated          |
|---------------------------|--------------------------|
| ** Original screenshot ** | ** updated screenshot ** |
